### PR TITLE
Simplify deploy

### DIFF
--- a/cmd/apl/app/helpers.go
+++ b/cmd/apl/app/helpers.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"github.com/applariat/roper"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"net/http"
 	"os"
@@ -189,7 +190,7 @@ func runCreateCommand(input interface{}, callMe interface{}) {
 // Helper to run the standard update command
 func runUpdateCommand(args []string, input interface{}, callMe interface{}) {
 
-	err := roper.Unmarshal(inputFile, input)
+	err := processInputFile(input)
 	if err != nil {
 		printResults(NewCLIError(err.Error()))
 		return

--- a/cmd/apl/app/helpers.go
+++ b/cmd/apl/app/helpers.go
@@ -165,7 +165,7 @@ func runGetCommand(args []string, callMe interface{}) interface{} {
 // Helper to run the standard create command
 func runCreateCommand(input interface{}, callMe interface{}) {
 
-	err := roper.Unmarshal(inputFile, input)
+	err := processInputFile(input)
 	if err != nil {
 		printResults(NewCLIError(err.Error()))
 		return
@@ -239,8 +239,12 @@ func runDeleteCommand(args []string, callMe interface{}) {
 
 }
 
+func isInputFileDefined() bool {
+	return inputFile != ""
+}
+
 func checkInputFileDefined() error {
-	if inputFile == "" {
+	if !isInputFileDefined() {
 		return fmt.Errorf("Input for create/update: json|yaml|-")
 	}
 	return nil
@@ -248,6 +252,14 @@ func checkInputFileDefined() error {
 
 func addInputFileFlag(ccmd *cobra.Command) {
 	ccmd.PersistentFlags().StringVarP(&inputFile, "file", "f", "", "Input for create/update: json|yaml|-")
+}
+
+func processInputFile(input interface{}) error {
+	// We check to see if inputFile flag is populated
+	if isInputFileDefined() {
+		return roper.Unmarshal(inputFile, input)
+	}
+	return nil
 }
 
 // Helper to cast response

--- a/cmd/apl/app/stack_artifacts_command.go
+++ b/cmd/apl/app/stack_artifacts_command.go
@@ -5,31 +5,50 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stackArtifactParams apl.StackArtifactParams
+var (
+	stackArtifactParams      apl.StackArtifactParams
+	stackArtifactCreateInput apl.StackArtifactCreateInput
+)
 
 // NewStackArtifactsCommand Creates a cobra command for StackArtifacts
 func NewStackArtifactsCommand() *cobra.Command {
 
-	cmd := createListCommand(cmdListStackArtifacts, "stack-artifacts", "")
-	getCmd := createGetCommand(cmdGetStackArtifacts, "stack-artifact", "")
-	createCmd := createCreateCommand(cmdCreateStackArtifacts, "stack-artifact", "")
-	updateCmd := createUpdateCommand(cmdUpdateStackArtifacts, "stack-artifact", "")
-	deleteCmd := createDeleteCommand(cmdDeleteStackArtifacts, "stack-artifact", "")
-
 	// command flags
+	cmd := createListCommand(cmdListStackArtifacts, "stack-artifacts", "")
 	cmd.Flags().StringVar(&stackArtifactParams.Name, "name", "", "Filter stack-artifacts by name")
 	cmd.Flags().StringVar(&stackArtifactParams.LocArtifactID, "loc-artifact-id", "", "Filter stack-artifacts by loc_artifact_id")
 	cmd.Flags().StringVar(&stackArtifactParams.ProjectID, "project-id", "", "Filter stack-artifacts by project_id")
 	cmd.Flags().StringVar(&stackArtifactParams.StackID, "stack-id", "", "Filter stack-artifacts by stack_id")
-	cmd.Flags().StringVar(&stackArtifactParams.Type, "type", "", "Filter stack-artifacts by type")
+	cmd.Flags().StringVar(&stackArtifactParams.StackArtifactType, "type", "", "Filter stack-artifacts by [code|config|image|data|builder]")
 	cmd.Flags().StringVar(&stackArtifactParams.Version, "version", "", "Filter stack-artifacts by version")
 	cmd.Flags().StringVar(&stackArtifactParams.ArtifactName, "artifact-name", "", "Filter stack-artifacts by artifact_name")
 	cmd.Flags().StringVar(&stackArtifactParams.Package, "package", "", "Filter stack-artifacts by package")
 
-	// add sub commands
+	// Get
+	getCmd := createGetCommand(cmdGetStackArtifacts, "stack-artifact", "")
 	cmd.AddCommand(getCmd)
+
+	// Create
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "create a stack-artifact",
+		Run:   cmdCreateStackArtifacts,
+	}
+	addInputFileFlag(createCmd)
+	createCmd.Flags().StringVar(&stackArtifactCreateInput.ID, "id", "", "")
+	createCmd.Flags().StringVar(&stackArtifactCreateInput.LocArtifactID, "loc-artifact-id", "", "")
+	createCmd.Flags().StringVar(&stackArtifactCreateInput.StackID, "stack-id", "", "")
+	createCmd.Flags().StringVar(&stackArtifactCreateInput.ArtifactName, "artifact-name", "", "")
+	createCmd.Flags().StringVar(&stackArtifactCreateInput.Name, "name", "", "")
+	createCmd.Flags().StringVar(&stackArtifactCreateInput.StackArtifactType, "stack-artifact-type", "", "[code|config|image|data|builder]")
 	cmd.AddCommand(createCmd)
+
+	// Update
+	updateCmd := createUpdateCommand(cmdUpdateStackArtifacts, "stack-artifact", "")
 	cmd.AddCommand(updateCmd)
+
+	// Delete
+	deleteCmd := createDeleteCommand(cmdDeleteStackArtifacts, "stack-artifact", "")
 	cmd.AddCommand(deleteCmd)
 
 	return cmd
@@ -57,7 +76,11 @@ func cmdGetStackArtifacts(ccmd *cobra.Command, args []string) {
 
 func cmdCreateStackArtifacts(ccmd *cobra.Command, args []string) {
 	aplSvs := apl.NewClient()
+
 	in := &apl.StackArtifactCreateInput{}
+	if !isInputFileDefined() {
+		in = &stackArtifactCreateInput
+	}
 	runCreateCommand(in, aplSvs.StackArtifacts.Create)
 }
 

--- a/pkg/apl/deployment_service.go
+++ b/pkg/apl/deployment_service.go
@@ -60,7 +60,7 @@ type DeploymentCreateInput struct {
 // DeploymentCmdComponent components for command update
 type DeploymentComponent struct {
 	StackComponentID string    `json:"stack_component_id"`
-	Name string `json:"name,omitempty"`
+	Name             string    `json:"name,omitempty"`
 	Services         []Service `json:"services,omitempty"`
 }
 

--- a/pkg/apl/deployment_service.go
+++ b/pkg/apl/deployment_service.go
@@ -57,16 +57,24 @@ type DeploymentCreateInput struct {
 	Components      interface{} `json:"components,omitempty"`
 }
 
+// DeploymentCmdComponent components for command update
+type DeploymentComponent struct {
+	StackComponentID string    `json:"stack_component_id"`
+	Name string `json:"name,omitempty"`
+	Services         []Service `json:"services,omitempty"`
+}
+
 // DeploymentUpdateInput used to update a deployment
 type DeploymentUpdateInput struct {
-	Name                 string `json:"name,omitempty"`
-	LeaseType            string `json:"lease_type,omitempty"`
-	LeasePeriodDays      int    `json:"lease_period_days,omitempty"`
-	LeaseExpirationEpoch int64  `json:"lease_expiration_epoch,omitempty"`
-	WorkloadName         string `json:"workload_name,omitempty"`
-	LeaseExpiration      string `json:"lease_expiration,omitempty"`
-	QosLevel             string `json:"qos_level,omitempty"`
-	Command              string `json:"command,omitempty"`
+	Name                 string                `json:"name,omitempty"`
+	LeaseType            string                `json:"lease_type,omitempty"`
+	LeasePeriodDays      int                   `json:"lease_period_days,omitempty"`
+	LeaseExpirationEpoch int64                 `json:"lease_expiration_epoch,omitempty"`
+	WorkloadName         string                `json:"workload_name,omitempty"`
+	LeaseExpiration      string                `json:"lease_expiration,omitempty"`
+	QosLevel             string                `json:"qos_level,omitempty"`
+	Command              string                `json:"command,omitempty"`
+	Components           []DeploymentComponent `json:"components,omitempty"`
 }
 
 // DeploymentParams filter parameters used in list operations

--- a/pkg/apl/stack_artifact_service.go
+++ b/pkg/apl/stack_artifact_service.go
@@ -38,11 +38,12 @@ type StackArtifact struct {
 
 // StackArtifactCreateInput is used for the create of stack_artifacts
 type StackArtifactCreateInput struct {
-	ID            string `json:"id,omitempty"`
-	LocArtifactID string `json:"loc_artifact_id"`
-	StackID       string `json:"stack_id"`
-	Name          string `json:"name"`
-	ArtifactName  string `json:"artifact_name"`
+	ID                string `json:"id,omitempty"`
+	LocArtifactID     string `json:"loc_artifact_id"`
+	StackID           string `json:"stack_id"`
+	Name              string `json:"name"`
+	ArtifactName      string `json:"artifact_name"`
+	StackArtifactType string `json:"stack_artifact_type"`
 
 	// Version is optional, will be auto-generated
 	Version string `json:"version,omitempty"`
@@ -57,14 +58,14 @@ type StackArtifactUpdateInput struct {
 
 // StackArtifactParams filter parameters used in list operations
 type StackArtifactParams struct {
-	LocArtifactID string `url:"loc_artifact_id,omitempty"`
-	ProjectID     string `url:"project_id,omitempty"`
-	StackID       string `url:"stack_id,omitempty"`
-	Name          string `url:"name,omitempty"`
-	Type          string `url:"type,omitempty"`
-	Version       string `url:"version,omitempty"`
-	ArtifactName  string `url:"artifact_name,omitempty"`
-	Package       string `url:"package,omitempty"`
+	LocArtifactID     string `url:"loc_artifact_id,omitempty"`
+	ProjectID         string `url:"project_id,omitempty"`
+	StackID           string `url:"stack_id,omitempty"`
+	Name              string `url:"name,omitempty"`
+	StackArtifactType string `url:"stack_artifact_type,omitempty"`
+	Version           string `url:"version,omitempty"`
+	ArtifactName      string `url:"artifact_name,omitempty"`
+	Package           string `url:"package,omitempty"`
 }
 
 // List gets a list of stack_artifacts with optional filter params

--- a/pkg/apl/stack_artifact_service.go
+++ b/pkg/apl/stack_artifact_service.go
@@ -22,18 +22,18 @@ func NewStackArtifactsService(sling *sling.Sling) *StackArtifactService {
 
 // StackArtifact represents a stack_artifact row
 type StackArtifact struct {
-	ID              string `json:"id,omitempty"`
-	CreatedByUserID string `json:"created_by_user_id"`
-	ArtifactName    string `json:"artifact_name"`
-	Name            string `json:"name"`
-	Package         string `json:"package"`
-	StackID         string `json:"stack_id"`
-	LocArtifactID   string `json:"loc_artifact_id"`
-	LastModified    string `json:"last_modified"`
-	Version         string `json:"version"`
-	CreatedTime     string `json:"created_time"`
-	ProjectID       string `json:"project_id"`
-	Type            string `json:"type"`
+	ID                string `json:"id,omitempty"`
+	CreatedByUserID   string `json:"created_by_user_id"`
+	ArtifactName      string `json:"artifact_name"`
+	Name              string `json:"name"`
+	Package           string `json:"package"`
+	StackID           string `json:"stack_id"`
+	LocArtifactID     string `json:"loc_artifact_id"`
+	LastModified      string `json:"last_modified"`
+	Version           string `json:"version"`
+	CreatedTime       string `json:"created_time"`
+	ProjectID         string `json:"project_id"`
+	StackArtifactType string `json:"stack_artifact_type"`
 }
 
 // StackArtifactCreateInput is used for the create of stack_artifacts

--- a/pkg/apl/types.go
+++ b/pkg/apl/types.go
@@ -59,6 +59,39 @@ type Releases struct {
 	MetaData `json:"meta_data"`
 } // `json:"releases"`
 
+// Artifact
+type Artifact struct {
+	Code    interface{} `json:"code,omitempty"`
+	Config  string `json:"config,omitempty"`
+	Image   string `json:"image,omitempty"`
+	Data    string `json:"data,omitempty"`
+	Builder string `json:"builder,omitempty"`
+} // `json:"artifacts"`
+
+// Build
+type Build struct {
+	Artifact  `json:"artifacts"`
+	BuildVars `json:"buildvars,omitempty"`
+} // `json:"build,omitempty"`
+
+// Service
+type Service struct {
+	ComponentServiceID string `json:"component_service_id"`
+	Build              `json:"build,omitempty"`
+	Run                `json:"run,omitempty"`
+}
+
+// BuildVars
+type BuildVars []map[string]string // `json:"buildvars,omitempty"`
+
+// EnvVars
+type EnvVars []map[string]string // `json:"envvars,omitempty"`
+
+// Run
+type Run struct {
+	Instances int `json:"instances,omitempty"`
+} // `json:"run,omitempty"`
+
 //// HealthProbe ...
 //type HealthProbe   struct {
 //	Delay   interface{} `json:"delay,omitempty"`

--- a/pkg/apl/types.go
+++ b/pkg/apl/types.go
@@ -62,10 +62,10 @@ type Releases struct {
 // Artifact
 type Artifact struct {
 	Code    interface{} `json:"code,omitempty"`
-	Config  string `json:"config,omitempty"`
-	Image   string `json:"image,omitempty"`
-	Data    string `json:"data,omitempty"`
-	Builder string `json:"builder,omitempty"`
+	Config  string      `json:"config,omitempty"`
+	Image   string      `json:"image,omitempty"`
+	Data    string      `json:"data,omitempty"`
+	Builder string      `json:"builder,omitempty"`
 } // `json:"artifacts"`
 
 // Build

--- a/tests/integration/stack_artifact_service_test.go
+++ b/tests/integration/stack_artifact_service_test.go
@@ -16,12 +16,13 @@ var (
 func TestStackArtifactService_Create(t *testing.T) {
 
 	in := &apl.StackArtifactCreateInput{
-		ID:            testStackArtifactId,
-		Name:          "Chris Test Zip",
-		ArtifactName:  "Chris/chris.zip",
-		LocArtifactID: "la-gs-apl",
-		StackID:       "aa409e87-70ef-4977-8588-10a618a1612f",
-		Version:       "1.1.1",
+		ID:                testStackArtifactId,
+		Name:              "Chris Test Zip",
+		ArtifactName:      "Chris/chris.zip",
+		LocArtifactID:     "la-gs-apl",
+		StackID:           "aa409e87-70ef-4977-8588-10a618a1612f",
+		Version:           "1.1.1",
+		StackArtifactType: "code",
 	}
 
 	out, _, err := aplClient.StackArtifacts.Create(in)


### PR DESCRIPTION
added the ability to override a component stack artifact. This is an update operation.

Example:
`apl deployments override <deploy-id> \
        --stack-component-id <sc-id> \
        --component-service-id <cs-id> \
        --stack-artifact-id <sa-id> \
       ---instances <int>(optional)`
