### PR TITLE
[WIP] Multiple Components on Command Line + Dry Run

### DIFF
--- a/cmd/apl/app/apl.go
+++ b/cmd/apl/app/apl.go
@@ -7,6 +7,7 @@ import (
 var (
 	printerType string
 	inputFile   string
+	dryRunFlag      bool
 
 	// AppLariatCmd The appLariat (apl) Command Line Interface is a unified tool to manage your appLariat service.
 	// You can control all appLariat services from the command line and automate them through scripts.
@@ -30,6 +31,7 @@ func init() {
 
 	// persistent flags, globals
 	AppLariatCmd.PersistentFlags().StringVarP(&printerType, "output", "o", "table", "Output format: json|yaml")
+	AppLariatCmd.PersistentFlags().BoolVarP(&dryRunFlag, "dry-run", "d", false, "Dry run")
 
 	// Commands
 

--- a/cmd/apl/app/apl.go
+++ b/cmd/apl/app/apl.go
@@ -7,7 +7,7 @@ import (
 var (
 	printerType string
 	inputFile   string
-	dryRunFlag      bool
+	dryRunFlag  bool
 
 	// AppLariatCmd The appLariat (apl) Command Line Interface is a unified tool to manage your appLariat service.
 	// You can control all appLariat services from the command line and automate them through scripts.

--- a/cmd/apl/app/custom_flag.go
+++ b/cmd/apl/app/custom_flag.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Implement the flag.Value interface
+// example flag --component "StackComponentID=my-scID,ServiceName=my-service,StackArtifactID=1,StackArtifactID=2,Instances=1"
+// You can pass in as many --component flags as you want.
+
+const (
+	mapStackComponentID = "StackComponentID"
+	mapServiceName      = "ServiceName"
+	mapStackArtifactID  = "StackArtifactID"
+	mapInstances        = "Instances"
+)
+
+type ComponentArgs struct {
+	OriginalValue    string
+	StackComponentID string
+	ServiceName      string
+	StackArtifactIDs []string
+	Instances        int
+}
+
+type ComponentStringMap struct {
+	Values []ComponentArgs
+}
+
+// Set takes in the key=value pairs, validates them and then assigns to struct value
+func (s *ComponentStringMap) Set(value string) error {
+
+	dc := ComponentArgs{}
+	dc.OriginalValue = value
+
+	// Split on comma to get key=value pairs
+	for _, arg := range strings.Split(value, ",") {
+
+		// split to key=value
+		x := strings.Split(arg, "=")
+		if len(x) < 2 {
+			return fmt.Errorf("Incorrect key=value format for %s", arg)
+		}
+
+		key := x[0]
+		value := x[1]
+
+		if value == "" {
+			return fmt.Errorf("value empty for key %s", key)
+		}
+
+		switch key {
+		case mapStackComponentID:
+			dc.StackComponentID = value
+		case mapServiceName:
+			dc.ServiceName = value
+		case mapStackArtifactID:
+			dc.StackArtifactIDs = append(dc.StackArtifactIDs, value)
+		case mapInstances:
+			// Sensible default here
+			dc.Instances = 1
+			instances, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("%s must be a number", key)
+			}
+			dc.Instances = instances
+		default:
+			return fmt.Errorf("Unsupported key %s", key)
+		}
+	}
+	s.Values = append(s.Values, dc)
+
+	return nil
+}
+
+func (s *ComponentStringMap) String() string {
+	return fmt.Sprintf("%v", *s)
+}
+
+func (s *ComponentStringMap) Type() string {
+	return fmt.Sprintf("%T", s)
+}
+
+func (s *ComponentStringMap) Usage() string {
+	return "\"StackComponentID=my-scID,ServiceName=my-service,StackArtifactID=1,StackArtifactID=2,Instances=1\""
+}

--- a/cmd/apl/app/deployments_command.go
+++ b/cmd/apl/app/deployments_command.go
@@ -4,22 +4,10 @@ import (
 	"fmt"
 	"github.com/applariat/go-apl/pkg/apl"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api/v1"
-	"strconv"
-	"time"
 )
 
 var (
-	deploymentParams             apl.DeploymentParams
-	deploymentWorkloadType       string
-	deploymentServiceName        string
-	deploymentReleaseID          string
-	deploymentLocDeployID        string
-	deploymentStackComponentID   string
-	deploymentStackArtifactID    string
-	deploymentComponentServiceID string
-	deploymentName               string
-	deploymentInstances          int
+	deploymentParams apl.DeploymentParams
 )
 
 // NewDeploymentsCommand Creates a cobra command for Deployments
@@ -37,58 +25,7 @@ func NewDeploymentsCommand() *cobra.Command {
 	cmd.AddCommand(getCmd)
 
 	// Create
-	createCmd := &cobra.Command{
-		Use:   "create",
-		Short: fmt.Sprintf("Create a deployment"),
-		Long:  "",
-		Run:   cmdCreateDeployments,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			var missingFlags []string
-
-			if deploymentName == "" {
-				missingFlags = append(missingFlags, "--name")
-			} else {
-				// sanitize name, must be dns friendly
-				deploymentName = subdomainSafe(deploymentName)
-			}
-
-			if deploymentReleaseID == "" {
-				missingFlags = append(missingFlags, "--release-id")
-			}
-
-			if deploymentLocDeployID == "" {
-				missingFlags = append(missingFlags, "--loc-deploy-id")
-			}
-
-			if deploymentStackComponentID == "" {
-				missingFlags = append(missingFlags, "--stack-component-id")
-			}
-
-			if deploymentServiceName == "" {
-				missingFlags = append(missingFlags, "--service-name")
-			}
-
-			if deploymentStackArtifactID == "" {
-				missingFlags = append(missingFlags, "--stack-artifact-id")
-			}
-
-			if len(missingFlags) > 0 {
-				return fmt.Errorf("Missing required flags: %s", missingFlags)
-			}
-
-			return nil
-		},
-	}
-
-	createCmd.Flags().StringVar(&deploymentName, "name", "", "")
-	createCmd.Flags().StringVar(&deploymentWorkloadType, "workload-type", "", "")
-	createCmd.Flags().StringVar(&deploymentReleaseID, "release-id", "", "")
-	createCmd.Flags().StringVar(&deploymentLocDeployID, "loc-deploy-id", "", "")
-	createCmd.Flags().StringVar(&deploymentStackComponentID, "stack-component-id", "", "")
-	createCmd.Flags().StringVar(&deploymentComponentServiceID, "component-service-id", "", "")
-	createCmd.Flags().StringVar(&deploymentServiceName, "service-name", "", "")
-	createCmd.Flags().StringVar(&deploymentStackArtifactID, "stack-artifact-id", "", "")
-	createCmd.Flags().IntVar(&deploymentInstances, "instances", 1, "")
+	createCmd := NewDeploymentsCreateCommand()
 	cmd.AddCommand(createCmd)
 
 	// Update
@@ -100,80 +37,15 @@ func NewDeploymentsCommand() *cobra.Command {
 	cmd.AddCommand(deleteCmd)
 
 	// Pods
-	podsCmd := &cobra.Command{
-		Use:   "pods [deployment-id]",
-		Short: fmt.Sprintf("get a list of pods"),
-		Long:  "",
-		Run:   cmdGetDeploymentPods,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return checkCommandHasIDInArgs(args, "deployment-id")
-		},
-	}
-	cmd.AddCommand(podsCmd)
+	//podsCmd := NewDeploymentsPodsCommand()
+	//cmd.AddCommand(podsCmd)
 
 	// Override
-	overrideCmd := &cobra.Command{
-		Use:   "override",
-		Short: fmt.Sprintf("Override a component artifact"),
-		Long:  "",
-		Run:   cmdOverrideDeployments,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			var missingFlags []string
-
-			if deploymentStackComponentID == "" {
-				missingFlags = append(missingFlags, "--stack-component-id")
-			}
-
-			if deploymentServiceName == "" {
-				missingFlags = append(missingFlags, "--service-name")
-			}
-
-			if deploymentStackArtifactID == "" {
-				missingFlags = append(missingFlags, "--stack-artifact-id")
-			}
-
-			if len(missingFlags) > 0 {
-				return fmt.Errorf("Missing required flags: %s", missingFlags)
-			}
-
-			return nil
-		},
-	}
-	overrideCmd.Flags().IntVar(&deploymentInstances, "instances", 1, "")
-	overrideCmd.Flags().StringVar(&deploymentStackComponentID, "stack-component-id", "", "")
-	overrideCmd.Flags().StringVar(&deploymentServiceName, "service-name", "", "")
-	overrideCmd.Flags().StringVar(&deploymentStackArtifactID, "stack-artifact-id", "", "")
-
+	overrideCmd := NewDeploymentsOverridesCommand()
 	cmd.AddCommand(overrideCmd)
 
 	// Scale Component
-	scaleComponentCmd := &cobra.Command{
-		Use:   "scale-component",
-		Short: fmt.Sprintf("Scale instances of a component"),
-		Long:  "",
-		Run:   cmdScaleComponentDeployments,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			var missingFlags []string
-
-			if deploymentStackComponentID == "" {
-				missingFlags = append(missingFlags, "--stack-component-id")
-			}
-
-			if deploymentServiceName == "" {
-				missingFlags = append(missingFlags, "--service-name")
-			}
-
-			if len(missingFlags) > 0 {
-				return fmt.Errorf("Missing required flags: %s", missingFlags)
-			}
-
-			return nil
-		},
-	}
-	scaleComponentCmd.Flags().IntVar(&deploymentInstances, "instances", 1, "")
-	scaleComponentCmd.Flags().StringVar(&deploymentStackComponentID, "stack-component-id", "", "")
-	scaleComponentCmd.Flags().StringVar(&deploymentServiceName, "component-service-id", "", "")
-
+	scaleComponentCmd := NewDeploymentsScaleCommand()
 	cmd.AddCommand(scaleComponentCmd)
 
 	return cmd
@@ -203,44 +75,6 @@ func cmdGetDeployments(ccmd *cobra.Command, args []string) {
 	}
 }
 
-func cmdCreateDeployments(ccmd *cobra.Command, args []string) {
-	aplSvc := apl.NewClient()
-
-	// this function will use the file or command line args for input.
-	in := &apl.DeploymentCreateInput{}
-
-	if !isInputFileDefined() {
-		artifact := artifactFactory(aplSvc, deploymentStackArtifactID)
-		in = &apl.DeploymentCreateInput{
-			Name:        deploymentName,
-			LocDeployID: deploymentLocDeployID,
-			ReleaseID:   deploymentReleaseID,
-			Components: []apl.DeploymentComponent{
-				{
-					StackComponentID: deploymentStackComponentID,
-					Services: []apl.Service{
-						{
-							ComponentServiceID: deploymentComponentServiceID,
-							Name:               deploymentServiceName,
-							Overrides: apl.Overrides{
-								Build: apl.Build{
-									Artifact: artifact,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		if deploymentWorkloadType != "" {
-			in.WorkloadType = deploymentWorkloadType
-		}
-	}
-
-	runCreateCommand(in, aplSvc.Deployments.Create)
-}
-
 func cmdUpdateDeployments(ccmd *cobra.Command, args []string) {
 	aplSvc := apl.NewClient()
 	in := &apl.DeploymentUpdateInput{}
@@ -252,185 +86,32 @@ func cmdDeleteDeployments(ccmd *cobra.Command, args []string) {
 	runDeleteCommand(args, aplSvc.Deployments.Delete)
 }
 
-// Override one component in deployment
-func cmdOverrideDeployments(ccmd *cobra.Command, args []string) {
-	aplSvc := apl.NewClient()
+// Utility functions
 
-	artifact := artifactFactory(aplSvc, deploymentStackArtifactID)
+// deploymentArtifactFactory fetches the type and builds the struct
+func deploymentArtifactFactory(aplSvc *apl.Client, stackArtifactIDs []string) apl.Artifact {
 
-	in := &apl.DeploymentUpdateInput{
-		Command: "override",
-		Components: []apl.DeploymentComponent{
-			{
-				StackComponentID: deploymentStackComponentID,
-				Services: []apl.Service{
-					{
-						Name: deploymentServiceName,
-						Build: apl.Build{
-							Artifact: artifact,
-						},
-						Run: apl.Run{
-							Instances: deploymentInstances,
-						},
-					},
-				},
-			},
-		},
-	}
+	var artifact apl.Artifact
 
-	runUpdateCommand(args, in, aplSvc.Deployments.Update)
-}
-
-func cmdScaleComponentDeployments(ccmd *cobra.Command, args []string) {
-	aplSvc := apl.NewClient()
-
-	in := &apl.DeploymentUpdateInput{
-		Command: "override",
-		Components: []apl.DeploymentComponent{
-			{
-				StackComponentID: deploymentStackComponentID,
-				Services: []apl.Service{
-					{
-						Name: deploymentServiceName,
-						Run: apl.Run{
-							Instances: deploymentInstances,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	runUpdateCommand(args, in, aplSvc.Deployments.Update)
-}
-
-func cmdGetDeploymentPods(ccmd *cobra.Command, args []string) {
-
-	aplSvc := apl.NewClient()
-
-	output := runGetCommand(args, aplSvc.Deployments.Get)
-
-	if output != nil {
-		deploy := output.(apl.Deployment)
-
-		namespace := deploy.Status.(map[string]interface{})["namespace"].(string)
-		//namespace := status["namespace"]
-		fmt.Println(namespace)
-
-		//fmt.Println(deploy.Status)
-
-		kubeSvc, err := apl.GetKubeClient()
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-		pods, err := kubeSvc.Core().Pods(namespace).List(v1.ListOptions{})
+	for _, saID := range stackArtifactIDs {
+		sa, _, err := aplSvc.StackArtifacts.Get(saID)
 		if err != nil {
 			panic(err.Error())
 		}
 
-		data := make([][]string, len(pods.Items))
-		for _, p := range pods.Items {
-			podInfo := printPod(&p)
-			data = append(data, podInfo)
-		}
-		header := []string{"Name", "Ready", "Status", "Restarts", "Age"}
-		//header := []string{"Name", "Ready", "Status", "Restarts"}
-		printTableResults(data, header)
-
-	}
-
-}
-
-// Copied from
-func printPod(pod *v1.Pod) []string {
-
-	restarts := 0
-	totalContainers := len(pod.Spec.Containers)
-	readyContainers := 0
-
-	reason := string(pod.Status.Phase)
-	if pod.Status.Reason != "" {
-		reason = pod.Status.Reason
-	}
-
-	initializing := false
-	for i := range pod.Status.InitContainerStatuses {
-		container := pod.Status.InitContainerStatuses[i]
-		restarts += int(container.RestartCount)
-		switch {
-		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
-			continue
-		case container.State.Terminated != nil:
-			// initialization is failed
-			if len(container.State.Terminated.Reason) == 0 {
-				if container.State.Terminated.Signal != 0 {
-					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
-				} else {
-					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
-				}
-			} else {
-				reason = "Init:" + container.State.Terminated.Reason
-			}
-			initializing = true
-		case container.State.Waiting != nil && len(container.State.Waiting.Reason) > 0 && container.State.Waiting.Reason != "PodInitializing":
-			reason = "Init:" + container.State.Waiting.Reason
-			initializing = true
+		switch sa.StackArtifactType {
+		case "code":
+			artifact.Code = saID
+		case "image":
+			artifact.Image = saID
+		case "config":
+			artifact.Config = saID
+		case "data":
+			artifact.Data = saID
 		default:
-			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
-			initializing = true
+			panic(fmt.Errorf("Unsupported StackArtifactType %s", sa.StackArtifactType))
 		}
-		break
+
 	}
-
-	if !initializing {
-		restarts = 0
-		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
-			container := pod.Status.ContainerStatuses[i]
-
-			restarts += int(container.RestartCount)
-			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
-				reason = container.State.Waiting.Reason
-			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
-				reason = container.State.Terminated.Reason
-			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
-				if container.State.Terminated.Signal != 0 {
-					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
-				} else {
-					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
-				}
-			} else if container.Ready && container.State.Running != nil {
-				readyContainers++
-			}
-		}
-	}
-
-	if pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {
-		reason = "Unknown"
-	} else if pod.DeletionTimestamp != nil {
-		reason = "Terminating"
-	}
-
-	age := "??"
-	if !pod.CreationTimestamp.IsZero() {
-		age = timeDuration(time.Now().Sub(pod.CreationTimestamp.Time))
-	}
-
-	//for _, refs := range pod.GetOwnerReferences() {
-	//	fmt.Println(refs.Kind)
-	//}
-
-	//annotations := pod.GetAnnotations()
-	//fmt.Println(annotations)
-	//fmt.Println(annotations["resource"])
-	//fmt.Println(annotations["resource"])
-
-	return []string{
-		pod.GetName(),
-		fmt.Sprintf("%d/%d", readyContainers, totalContainers),
-		reason,
-		strconv.Itoa(restarts),
-		age,
-	}
-
+	return artifact
 }

--- a/cmd/apl/app/deployments_create_comand.go
+++ b/cmd/apl/app/deployments_create_comand.go
@@ -46,9 +46,10 @@ func NewDeploymentsCreateCommand() *cobra.Command {
 				missingFlags = append(missingFlags, "--loc-deploy-id")
 			}
 
-			if len(componentsMap.Values) < 1 {
-				missingFlags = append(missingFlags, "--component")
-			}
+			// Should this be required? I don't think so.
+			//if len(componentsMap.Values) < 1 {
+			//	missingFlags = append(missingFlags, "--component")
+			//}
 
 			if len(missingFlags) > 0 {
 				return fmt.Errorf("Missing required flags: %s", missingFlags)

--- a/cmd/apl/app/deployments_create_comand.go
+++ b/cmd/apl/app/deployments_create_comand.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"fmt"
+	"github.com/applariat/go-apl/pkg/apl"
+	"github.com/spf13/cobra"
+)
+
+// NewDeploymentsCreateCommand
+func NewDeploymentsCreateCommand() *cobra.Command {
+
+	var (
+		name          string
+		releaseID     string
+		locDeployID   string
+		workloadType  string
+		instances     int
+		componentsMap ComponentStringMap
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: fmt.Sprintf("Create a deployment"),
+		Long:  "",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+
+			// If there is a file, no other checking is needed
+			if isInputFileDefined() {
+				return nil
+			}
+
+			var missingFlags []string
+
+			if name == "" {
+				missingFlags = append(missingFlags, "--name")
+			} else {
+				// sanitize name, must be dns friendly
+				name = subdomainSafe(name)
+			}
+
+			if releaseID == "" {
+				missingFlags = append(missingFlags, "--release-id")
+			}
+
+			if locDeployID == "" {
+				missingFlags = append(missingFlags, "--loc-deploy-id")
+			}
+
+			if len(componentsMap.Values) < 1 {
+				missingFlags = append(missingFlags, "--component")
+			}
+
+			if len(missingFlags) > 0 {
+				return fmt.Errorf("Missing required flags: %s", missingFlags)
+			}
+
+			return nil
+		},
+
+		Run: func(ccmd *cobra.Command, args []string) {
+			aplSvc := apl.NewClient()
+
+			// this function will use the file or command line args for input.
+			in := &apl.DeploymentCreateInput{}
+
+			if !isInputFileDefined() {
+
+				// Create the []apl.Components
+				c := []apl.DeploymentComponent{}
+				for _, cmp := range componentsMap.Values {
+
+					// build artifact
+					artifact := deploymentArtifactFactory(aplSvc, cmp.StackArtifactIDs)
+
+					dc := apl.DeploymentComponent{
+						StackComponentID: cmp.StackComponentID,
+						Services: []apl.Service{
+							{
+								Name: cmp.ServiceName,
+								Overrides: apl.Overrides{
+									Build: apl.Build{
+										Artifact: artifact,
+									},
+								},
+								//Run: apl.Run{
+								//	Instances: cmp.Instances,
+								//},
+							},
+						},
+					}
+					c = append(c, dc)
+
+				}
+
+				in = &apl.DeploymentCreateInput{
+					Name:        name,
+					LocDeployID: locDeployID,
+					ReleaseID:   releaseID,
+					Components:  c,
+				}
+
+				if workloadType != "" {
+					in.WorkloadType = workloadType
+				}
+
+			}
+
+			runCreateCommand(in, aplSvc.Deployments.Create)
+		},
+	}
+	addInputFileFlag(cmd)
+	cmd.Flags().StringVar(&name, "name", "", "")
+	cmd.Flags().StringVar(&workloadType, "workload-type", "", "")
+	cmd.Flags().StringVar(&releaseID, "release-id", "", "")
+	cmd.Flags().StringVar(&locDeployID, "loc-deploy-id", "", "")
+	cmd.Flags().Var(&componentsMap, "component", componentsMap.Usage())
+
+	cmd.Flags().IntVar(&instances, "instances", 1, "")
+
+	return cmd
+}

--- a/cmd/apl/app/deployments_overrides_command.go
+++ b/cmd/apl/app/deployments_overrides_command.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"fmt"
+	"github.com/applariat/go-apl/pkg/apl"
+	"github.com/spf13/cobra"
+)
+
+// NewDeploymentsOverridesCommand
+func NewDeploymentsOverridesCommand() *cobra.Command {
+
+	var componentsMap ComponentStringMap
+
+	cmd := &cobra.Command{
+		Use:   "override",
+		Short: fmt.Sprintf("Override a component artifact"),
+		Long:  "",
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+
+			// If there is a file, no other checking is needed
+			if isInputFileDefined() {
+				return nil
+			}
+
+			var missingFlags []string
+
+			if len(componentsMap.Values) <= 0 {
+				missingFlags = append(missingFlags, "--component")
+			}
+
+			if len(missingFlags) > 0 {
+				return fmt.Errorf("Missing required flags: %s", missingFlags)
+			}
+
+			return nil
+		},
+
+		Run: func(ccmd *cobra.Command, args []string) {
+			aplSvc := apl.NewClient()
+
+			in := &apl.DeploymentUpdateInput{}
+
+			if !isInputFileDefined() {
+
+				// Create the []apl.Components
+				c := []apl.DeploymentComponent{}
+				for _, cmp := range componentsMap.Values {
+
+					artifact := deploymentArtifactFactory(aplSvc, cmp.StackArtifactIDs)
+
+					dc := apl.DeploymentComponent{
+						StackComponentID: cmp.StackComponentID,
+						Services: []apl.Service{
+							{
+								Name: cmp.ServiceName,
+								Build: apl.Build{
+									Artifact: artifact,
+								},
+								Run: apl.Run{
+									Instances: cmp.Instances,
+								},
+							},
+						},
+					}
+
+					c = append(c, dc)
+
+				}
+
+				in = &apl.DeploymentUpdateInput{
+					Command:    "override",
+					Components: c,
+				}
+
+			}
+
+			runUpdateCommand(args, in, aplSvc.Deployments.Update)
+		},
+	}
+
+	cmd.Flags().Var(&componentsMap, "component", componentsMap.Usage())
+	return cmd
+}

--- a/cmd/apl/app/deployments_pods_command.go
+++ b/cmd/apl/app/deployments_pods_command.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"fmt"
+	"github.com/applariat/go-apl/pkg/apl"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/pkg/api/v1"
+	"strconv"
+	"time"
+)
+
+// NewDeploymentsPodsCommand
+func NewDeploymentsPodsCommand() *cobra.Command {
+
+	// Pods
+	cmd := &cobra.Command{
+		Use:   "pods [deployment-id]",
+		Short: fmt.Sprintf("get a list of pods"),
+		Long:  "",
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return checkCommandHasIDInArgs(args, "deployment-id")
+		},
+
+		Run: func(ccmd *cobra.Command, args []string) {
+
+			aplSvc := apl.NewClient()
+
+			output := runGetCommand(args, aplSvc.Deployments.Get)
+
+			if output != nil {
+				deploy := output.(apl.Deployment)
+
+				namespace := deploy.Status.(map[string]interface{})["namespace"].(string)
+				//namespace := status["namespace"]
+				fmt.Println(namespace)
+
+				//fmt.Println(deploy.Status)
+
+				kubeSvc, err := apl.GetKubeClient()
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+				pods, err := kubeSvc.Core().Pods(namespace).List(v1.ListOptions{})
+				if err != nil {
+					panic(err.Error())
+				}
+
+				data := make([][]string, len(pods.Items))
+				for _, p := range pods.Items {
+					podInfo := printPod(&p)
+					data = append(data, podInfo)
+				}
+				header := []string{"Name", "Ready", "Status", "Restarts", "Age"}
+				//header := []string{"Name", "Ready", "Status", "Restarts"}
+				printTableResults(data, header)
+
+			}
+
+		},
+	}
+
+	return cmd
+
+}
+
+//
+func printPod(pod *v1.Pod) []string {
+
+	restarts := 0
+	totalContainers := len(pod.Spec.Containers)
+	readyContainers := 0
+
+	reason := string(pod.Status.Phase)
+	if pod.Status.Reason != "" {
+		reason = pod.Status.Reason
+	}
+
+	initializing := false
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		restarts += int(container.RestartCount)
+		switch {
+		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
+			continue
+		case container.State.Terminated != nil:
+			// initialization is failed
+			if len(container.State.Terminated.Reason) == 0 {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else {
+				reason = "Init:" + container.State.Terminated.Reason
+			}
+			initializing = true
+		case container.State.Waiting != nil && len(container.State.Waiting.Reason) > 0 && container.State.Waiting.Reason != "PodInitializing":
+			reason = "Init:" + container.State.Waiting.Reason
+			initializing = true
+		default:
+			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+			initializing = true
+		}
+		break
+	}
+
+	if !initializing {
+		restarts = 0
+		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+			container := pod.Status.ContainerStatuses[i]
+
+			restarts += int(container.RestartCount)
+			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
+				reason = container.State.Waiting.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
+				reason = container.State.Terminated.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else if container.Ready && container.State.Running != nil {
+				readyContainers++
+			}
+		}
+	}
+
+	if pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {
+		reason = "Unknown"
+	} else if pod.DeletionTimestamp != nil {
+		reason = "Terminating"
+	}
+
+	age := "??"
+	if !pod.CreationTimestamp.IsZero() {
+		age = timeDuration(time.Now().Sub(pod.CreationTimestamp.Time))
+	}
+
+	//for _, refs := range pod.GetOwnerReferences() {
+	//	fmt.Println(refs.Kind)
+	//}
+
+	//annotations := pod.GetAnnotations()
+	//fmt.Println(annotations)
+	//fmt.Println(annotations["resource"])
+	//fmt.Println(annotations["resource"])
+
+	return []string{
+		pod.GetName(),
+		fmt.Sprintf("%d/%d", readyContainers, totalContainers),
+		reason,
+		strconv.Itoa(restarts),
+		age,
+	}
+
+}

--- a/cmd/apl/app/deployments_scale_command.go
+++ b/cmd/apl/app/deployments_scale_command.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"fmt"
+	"github.com/applariat/go-apl/pkg/apl"
+	"github.com/spf13/cobra"
+)
+
+// NewDeploymentsScaleCommand
+func NewDeploymentsScaleCommand() *cobra.Command {
+	var (
+		serviceName      string
+		stackComponentID string
+		instances        int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "scale-component",
+		Short: fmt.Sprintf("Scale instances of a component"),
+		Long:  "",
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			var missingFlags []string
+
+			if stackComponentID == "" {
+				missingFlags = append(missingFlags, "--stack-component-id")
+			}
+
+			if serviceName == "" {
+				missingFlags = append(missingFlags, "--service-name")
+			}
+
+			if len(missingFlags) > 0 {
+				return fmt.Errorf("Missing required flags: %s", missingFlags)
+			}
+
+			return nil
+		},
+
+		Run: func(ccmd *cobra.Command, args []string) {
+			aplSvc := apl.NewClient()
+
+			in := &apl.DeploymentUpdateInput{
+				Command: "override",
+				Components: []apl.DeploymentComponent{
+					{
+						StackComponentID: stackComponentID,
+						Services: []apl.Service{
+							{
+								Name: serviceName,
+								Run: apl.Run{
+									Instances: instances,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			runUpdateCommand(args, in, aplSvc.Deployments.Update)
+		},
+	}
+	cmd.Flags().IntVar(&instances, "instances", 1, "")
+	cmd.Flags().StringVar(&stackComponentID, "stack-component-id", "", "")
+	cmd.Flags().StringVar(&serviceName, "component-service-id", "", "")
+
+	return cmd
+}

--- a/cmd/apl/app/releases_command.go
+++ b/cmd/apl/app/releases_command.go
@@ -5,15 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	releaseParams           apl.ReleaseParams
-	releaseName             string
-	releaseStackID          string
-	releaseStackVersionID   string
-	releaseStackComponentID string
-	releaseServiceName      string
-	releaseStackArtifactID  string
-)
+var releaseParams apl.ReleaseParams
 
 // NewReleasesCommand Creates a cobra command for Releases
 func NewReleasesCommand() *cobra.Command {
@@ -32,56 +24,7 @@ func NewReleasesCommand() *cobra.Command {
 	cmd.AddCommand(getCmd)
 
 	// Create
-	createCmd := createCreateCommand(cmdCreateReleases, "release", "")
-	//createCmd := &cobra.Command{
-	//	Use:   "create",
-	//	Short: fmt.Sprintf("Create a release"),
-	//	Long:  "",
-	//	Run:   cmdCreateReleases,
-	//	PreRunE: func(cmd *cobra.Command, args []string) error {
-	//		var missingFlags []string
-	//
-	//		if releaseName == "" {
-	//			missingFlags = append(missingFlags, "--name")
-	//		} else {
-	//			// sanitize name, must be dns friendly
-	//			releaseName = subdomainSafe(releaseName)
-	//		}
-	//
-	//		if releaseStackID == "" {
-	//			missingFlags = append(missingFlags, "--stack-id")
-	//		}
-	//
-	//		if releaseStackVersionID == "" {
-	//			missingFlags = append(missingFlags, "--stack-version-id")
-	//		}
-	//
-	//		if releaseStackComponentID == "" {
-	//			missingFlags = append(missingFlags, "--stack-component-id")
-	//		}
-	//
-	//		if releaseServiceName == "" {
-	//			missingFlags = append(missingFlags, "--service-name")
-	//		}
-	//
-	//		if releaseStackArtifactID == "" {
-	//			missingFlags = append(missingFlags, "--stack-artifact-id")
-	//		}
-	//
-	//		if len(missingFlags) > 0 {
-	//			return fmt.Errorf("Missing required flags: %s", missingFlags)
-	//		}
-	//
-	//		return nil
-	//	},
-	//}
-	//
-	//createCmd.Flags().StringVar(&releaseName, "name", "", "")
-	//createCmd.Flags().StringVar(&releaseStackID, "stack-id", "", "")
-	//createCmd.Flags().StringVar(&releaseStackVersionID, "stack-version-id", "", "")
-	//createCmd.Flags().StringVar(&releaseStackComponentID, "stack-component-id", "", "")
-	//createCmd.Flags().StringVar(&releaseServiceName, "service-name", "", "")
-	//createCmd.Flags().StringVar(&releaseStackArtifactID, "stack-artifact-id", "", "")
+	createCmd := NewReleasesCreateCommand()
 	cmd.AddCommand(createCmd)
 
 	// Delete
@@ -109,52 +52,6 @@ func cmdGetReleases(ccmd *cobra.Command, args []string) {
 		fields := []string{"ID", "StackID", "Version", "CreatedTime"}
 		printTableResultsCustom(output.(apl.Release), fields)
 	}
-}
-
-func cmdCreateReleases(ccmd *cobra.Command, args []string) {
-	aplSvc := apl.NewClient()
-	in := &apl.ReleaseCreateInput{}
-
-	//if !isInputFileDefined() {
-	//	//artifact := artifactFactory(aplSvc, releaseStackArtifactID)
-	//
-	//	components := []map[string]interface{} {
-	//			StackComponentID string                    `json:"stack_component_id,omitempty"`
-	//			Name             string                    `json:"name,omitempty"`
-	//			Services         []struct {
-	//				Name             string `json:"name,omitempty"`
-	//				ReleaseArtifacts `json:"release,omitempty"`
-	//			}, `json:"services,omitempty"`
-	//	}
-	//
-	//	in = &apl.ReleaseCreateInput{
-	//		MetaData: &apl.MetaData{
-	//			DisplayName: releaseName,
-	//		},
-	//		StackID:        releaseStackID,
-	//		StackVersionID: releaseStackVersionID,
-	//		//Components: []apl.ReleaseComponent{
-	//		//	{
-	//		//		StackComponentID: releaseStackComponentID,
-	//		//		Services: []apl.ReleaseComponentService{
-	//		//			{
-	//		//				Name: releaseServiceName,
-	//		//				ReleaseArtifacts: apl.ReleaseArtifacts{
-	//		//					Artifact: apl.ReleaseArtifacts{
-	//		//						Code:
-	//		//					}
-	//		//					Artifact: artifact,
-	//		//				},
-	//		//			},
-	//		//		},
-	//		//	},
-	//		//},
-	//	}
-	//}
-
-	//printYAML(in)
-
-	runCreateCommand(in, aplSvc.Releases.Create)
 }
 
 func cmdDeleteReleases(ccmd *cobra.Command, args []string) {

--- a/cmd/apl/app/releases_create_command.go
+++ b/cmd/apl/app/releases_create_command.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"fmt"
+	"github.com/applariat/go-apl/pkg/apl"
+	"github.com/spf13/cobra"
+)
+
+func NewReleasesCreateCommand() *cobra.Command {
+	var (
+		releaseName           string
+		releaseStackID        string
+		releaseStackVersionID string
+		componentsMap         ComponentStringMap
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: fmt.Sprintf("Create a release"),
+		Long:  "",
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+
+			// If there is a file, no other checking is needed
+			if isInputFileDefined() {
+				return nil
+			}
+
+			var missingFlags []string
+
+			if releaseName == "" {
+				missingFlags = append(missingFlags, "--name")
+			} else {
+				// sanitize name, must be dns friendly
+				releaseName = subdomainSafe(releaseName)
+			}
+
+			if releaseStackID == "" {
+				missingFlags = append(missingFlags, "--stack-id")
+			}
+
+			if releaseStackVersionID == "" {
+				missingFlags = append(missingFlags, "--stack-version-id")
+			}
+
+			if len(componentsMap.Values) <= 0 {
+				missingFlags = append(missingFlags, "--component")
+			}
+
+			if len(missingFlags) > 0 {
+				return fmt.Errorf("Missing required flags: %s", missingFlags)
+			}
+
+			return nil
+		},
+
+		Run: func(ccmd *cobra.Command, args []string) {
+			aplSvc := apl.NewClient()
+			in := &apl.ReleaseCreateInput{}
+
+			if !isInputFileDefined() {
+
+				c := []apl.ReleaseOverrideComponent{}
+				for _, cmp := range componentsMap.Values {
+
+					artifact := releaseArtifactFactory(aplSvc, cmp.StackArtifactIDs)
+
+					roc := apl.ReleaseOverrideComponent{
+						Name:             cmp.ServiceName,
+						StackComponentID: cmp.StackComponentID,
+						Services: []apl.ReleaseOverrideService{
+							{
+								Name: cmp.ServiceName,
+								Release: apl.ReleaseOverrideRelease{
+									Artifacts: artifact,
+								},
+							},
+						},
+					}
+
+					c = append(c, roc)
+				}
+
+				in = &apl.ReleaseCreateInput{
+					MetaData: apl.MetaData{
+						DisplayName: releaseName,
+					},
+					StackID:        releaseStackID,
+					StackVersionID: releaseStackVersionID,
+					Components:     c,
+				}
+
+			}
+
+			runCreateCommand(in, aplSvc.Releases.Create)
+		},
+	}
+
+	cmd.Flags().StringVar(&releaseName, "name", "", "")
+	cmd.Flags().StringVar(&releaseStackID, "stack-id", "", "")
+	cmd.Flags().StringVar(&releaseStackVersionID, "stack-version-id", "", "")
+	cmd.Flags().Var(&componentsMap, "component", componentsMap.Usage())
+
+	return cmd
+
+}
+
+// releaseArtifactFactory fetches the type and builds the struct
+func releaseArtifactFactory(aplSvc *apl.Client, stackArtifactIDs []string) apl.ReleaseOverrideArtifact {
+
+	artifact := apl.ReleaseOverrideArtifact{}
+
+	for _, saID := range stackArtifactIDs {
+
+		base := &apl.ReleaseOverrideArtifactBase{
+			StackArtifactID: saID,
+		}
+
+		sa, _, err := aplSvc.StackArtifacts.Get(saID)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		switch sa.StackArtifactType {
+		case "code":
+			artifact.Code = base
+		case "image":
+			artifact.Image = base
+		case "builder":
+			artifact.Builder = base
+		default:
+			panic(fmt.Errorf("Unsupported StackArtifactType %s", sa.StackArtifactType))
+		}
+
+	}
+	return artifact
+}

--- a/pkg/apl/release_service.go
+++ b/pkg/apl/release_service.go
@@ -50,42 +50,30 @@ type ReleaseCreateInput struct {
 	MetaData       interface{} `json:"meta_data,omitempty"`
 }
 
-//// ReleaseArtifact
-//type ReleaseArtifact struct {
-//	Code struct {
-//		StackArtifactID string `json:"stack_artifact_id,omitempty"`
-//	} `json:"code,omitempty"`
-//	Config struct {
-//		StackArtifactID string `json:"stack_artifact_id,omitempty"`
-//	} `json:"config,omitempty"`
-//	Image struct {
-//		StackArtifactID string `json:"stack_artifact_id,omitempty"`
-//	} `json:"image,omitempty"`
-//	Data struct {
-//		StackArtifactID string `json:"stack_artifact_id,omitempty"`
-//	} `json:"data,omitempty"`
-//	Builder struct {
-//		StackArtifactID string `json:"stack_artifact_id,omitempty"`
-//	} `json:"builder,omitempty"`
-//} // `json:"artifacts"`
-//
-//// ReleaseArtifacts
-//type ReleaseArtifacts struct {
-//	ReleaseArtifact `json:"artifacts"`
-//}
-//
-//// ReleaseComponentService
-//type ReleaseComponentService struct {
-//	Name             string `json:"name,omitempty"`
-//	ReleaseArtifacts `json:"release,omitempty"`
-//}
-//
-//// DeploymentCmdComponent components for command update
-//type ReleaseComponent struct {
-//	StackComponentID string                    `json:"stack_component_id,omitempty"`
-//	Name             string                    `json:"name,omitempty"`
-//	Services         []ReleaseComponentService `json:"services,omitempty"`
-//}
+type ReleaseOverrideArtifactBase struct {
+	StackArtifactID string `json:"stack_artifact_id,omitempty"`
+}
+
+type ReleaseOverrideArtifact struct {
+	Builder *ReleaseOverrideArtifactBase `json:"builder,omitempty"`
+	Code    *ReleaseOverrideArtifactBase `json:"code,omitempty"`
+	Image   *ReleaseOverrideArtifactBase `json:"image,omitempty"`
+} // `json:"artifacts"`
+
+type ReleaseOverrideRelease struct {
+	Artifacts ReleaseOverrideArtifact `json:"artifacts,omitempty"`
+} // `json:"release"`
+
+type ReleaseOverrideService struct {
+	Name    string                 `json:"name"`
+	Release ReleaseOverrideRelease `json:"release"`
+} // `json:"services"`
+
+type ReleaseOverrideComponent struct {
+	Name             string                   `json:"name"`
+	StackComponentID string                   `json:"stack_component_id"`
+	Services         []ReleaseOverrideService `json:"services"`
+} // `json:"components"`
 
 // ReleaseParams filter parameters used in list operations
 type ReleaseParams struct {


### PR DESCRIPTION
Added --dry-run flag. Prints yaml then exits.

Created a pflag.Value implementation to support passing multiple --component args.
The --component flag is opinionated. It only accepts certain keys. Here are the supported keys:
* StackComponentID
* ServiceName
* StackArtifactID (can specify multiple keys, will be converted to []string)
* Instances (only used by deployments)

Deployments and Releases now support the --component flags. This allows N number of components to be specified.